### PR TITLE
Agregar lógica faltante a las SAGAs

### DIFF
--- a/src/aeroalpes/modulos/sagas/aplicacion/coordinadores/saga_reservas.py
+++ b/src/aeroalpes/modulos/sagas/aplicacion/coordinadores/saga_reservas.py
@@ -14,7 +14,9 @@ from aeroalpes.modulos.sagas.dominio.eventos.gds import ReservaGDSConfirmada, Co
 
 
 class CoordinadorReservas(CoordinadorOrquestacion):
-
+    def __init__(self):
+            self.inicializar_pasos()
+        
     def inicializar_pasos(self):
         self.pasos = [
             Inicio(index=0),

--- a/src/aeroalpes/seedwork/aplicacion/sagas.py
+++ b/src/aeroalpes/seedwork/aplicacion/sagas.py
@@ -79,7 +79,7 @@ class CoordinadorOrquestacion(CoordinadorSaga, ABC):
         raise Exception("Evento no hace parte de la transacción")
                 
     def es_ultima_transaccion(self, index):
-        return len(self.pasos) - 1
+        return (len(self.pasos) - 1) == index
 
     def procesar_evento(self, evento: EventoDominio):
         paso, index = self.obtener_paso_dado_un_evento(evento)
@@ -88,6 +88,6 @@ class CoordinadorOrquestacion(CoordinadorSaga, ABC):
         elif isinstance(evento, paso.error):
             self.publicar_comando(evento, self.pasos[index-1].compensacion)
         elif isinstance(evento, paso.evento):
-            self.publicar_comando(evento, self.pasos[index+1].compensacion)
+            self.publicar_comando(evento, self.pasos[index+1].comando)
 
 


### PR DESCRIPTION
## Describa el cambio
+ Se ajusta la secuencia de enviar comando 
+ Para que funcione se debe hacer el init del CoordinadorReservas de esta forma ya inicializa los pasos definidos para la transacción.
+ Se ajusta validación para identificar si es la ultima transacción
## Razonamiento pedagógico
+ En términos pedagógicos, el cambio realizado en la secuencia de enviar comando se justifica por la necesidad de optimizar el funcionamiento del CoordinadorReservas, asegurando que los pasos necesarios para la transacción se inicialicen de manera adecuada. Al ajustar la secuencia y realizar el init del CoordinadorReservas de la forma especificada, garantizamos que los pasos definidos para la transacción estén correctamente configurados desde el inicio, lo que contribuye a que los nuevos estudiantes tengan una ejecución más eficiente y libre de posibles errores.

### Lista de chequeo
- [x] Ejecuté el proyecto de forma local o usando Gitpod
- [ ] Corrí todas las pruebas
- [ ] Agregué o modifiqué pruebas