### PR TITLE
fix docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,9 @@ services:
       - ./data/zookeeper:/pulsar/data/zookeeper
     environment:
       - metadataStoreUrl=zk:zookeeper:2181
-    command: bin/pulsar initialize-cluster-metadata --cluster cluster-a --zookeeper zookeeper:2181 --configuration-store zookeeper:2181 --web-service-url http://broker:8080 --broker-service-url pulsar://broker:6650
+    command: bash -c "bin/apply-config-from-env.py conf/zookeeper.conf && \
+             bin/generate-zookeeper-config.sh conf/zookeeper.conf && \
+             exec bin/pulsar zookeeper"
     healthcheck:
       test: ["CMD", "bin/pulsar-zookeeper-ruok.sh"]
       interval: 10s
@@ -33,12 +35,7 @@ services:
     networks:
       - pulsar
     command: >
-      bin/pulsar initialize-cluster-metadata \
-               --cluster cluster-a \
-               --zookeeper zookeeper:2181 \
-               --configuration-store zookeeper:2181 \
-               --web-service-url http://broker:8080 \
-               --broker-service-url pulsar://broker:6650
+      bin/pulsar initialize-cluster-metadata --cluster cluster-a --zookeeper zookeeper:2181 --configuration-store zookeeper:2181 --web-service-url http://broker:8080 --broker-service-url pulsar://broker:6650
     depends_on:
       zookeeper:
         condition: service_healthy


### PR DESCRIPTION
## Describa el cambio

1. El comando de zookeeper no funcionaba pues tenía el comando de pulsar-init sin indentación
2. El comando de pulsar-init funciona de manera más fácil sin identación

## Razonamiento pedagógico

Facilidad de los estudiantes para ejecutar los tutoriales sin inconvenientes

### Lista de chequeo
- [ ] Ejecuté el proyecto de forma local o usando Gitpod
- [ ] Corrí todas las pruebas
- [ ] Agregué o modifiqué pruebas